### PR TITLE
Feature/fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ String value = WalleChannelReader.get(context, "buildtime");
 
 我们推荐使用channelFile/configFile配置来生成渠道包，但有时也可能有临时生成渠道包需求，这时可以使用：
 
-- 生成单个渠道包：`./gradlew clean assembleReleaseChannels -PchannelList=meituan`
-- 生成多个渠道包 `./gradlew clean assembleReleaseChannels -PchannelList=meituan,dianping`
-- 生成渠道包&写入额外信息：`./gradlew clean assembleReleaseChannels -PchannelList=meituan -PextraInfo=buildtime:20161212,hash:xxxxxxx`
-  注意：这里的extraInfo以`key:value`形式提供，多个以`,`分隔。
+- 生成单个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan`
+- 生成多个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan,dianping`
+- 生成渠道包&写入额外信息:
+  `./gradlew clean assembleReleaseChannels -PchannelList=meituan -PextraInfo=buildtime:20161212,hash:xxxxxxx`
+  注意: 这里的extraInfo以`key:value`形式提供，多个以`,`分隔。
 
 使用上述-P参数后，本次打包channelFile/configFile配置将会失效，其他配置仍然有效。
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ String value = WalleChannelReader.get(context, "buildtime");
 
 - 生成单个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan`
 - 生成多个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan,dianping`
-- 生成渠道包&写入额外信息:
+- 生成渠道包&写入额外信息:  
   `./gradlew clean assembleReleaseChannels -PchannelList=meituan -PextraInfo=buildtime:20161212,hash:xxxxxxx`  
   注意: 这里的extraInfo以`key:value`形式提供，多个以`,`分隔。
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ if (channelInfo != null) {
 String value = WalleChannelReader.get(context, "buildtime");
 ```
 
+##### 临时生成某渠道包
+
+我们推荐使用channelFile/configFile配置来生成渠道包，但有时也可能有临时生成渠道包需求，这时可以使用：
+
+- 生成单个渠道包：`./gradlew clean assembleReleaseChannels -PchannelList=meituan`
+- 生成多个渠道包 `./gradlew clean assembleReleaseChannels -PchannelList=meituan,dianping`
+- 生成渠道包&写入额外信息：`./gradlew clean assembleReleaseChannels -PchannelList=meituan -PextraInfo=buildtime:20161212,hash:xxxxxxx`
+  注意：这里的extraInfo以`key:value`形式提供，多个以`,`分隔。
+
+使用上述-P参数后，本次打包channelFile/configFile配置将会失效，其他配置仍然有效。
+
 ### 命令行工具使用方式
 
 可以使用命令行工具来支持各类自定义的需求，具体使用方式详见：[Walle CLI 使用说明](walle-cli/README.md)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ String value = WalleChannelReader.get(context, "buildtime");
 - 生成单个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan`
 - 生成多个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan,dianping`
 - 生成渠道包&写入额外信息:  
+
   `./gradlew clean assembleReleaseChannels -PchannelList=meituan -PextraInfo=buildtime:20161212,hash:xxxxxxx`  
+  
   注意: 这里的extraInfo以`key:value`形式提供，多个以`,`分隔。
 
 使用上述-P参数后，本次打包channelFile/configFile配置将会失效，其他配置仍然有效。

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ String value = WalleChannelReader.get(context, "buildtime");
 
 - 生成单个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan`
 - 生成多个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan,dianping`
-- 生成渠道包&写入额外信息:  
-  `./gradlew clean assembleReleaseChannels -PchannelList=meituan -PextraInfo=buildtime:20161212,hash:xxxxxxx`
+- 生成渠道包&写入额外信息:
+  `./gradlew clean assembleReleaseChannels -PchannelList=meituan -PextraInfo=buildtime:20161212,hash:xxxxxxx`  
   注意: 这里的extraInfo以`key:value`形式提供，多个以`,`分隔。
 
 使用上述-P参数后，本次打包channelFile/configFile配置将会失效，其他配置仍然有效。

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ String value = WalleChannelReader.get(context, "buildtime");
 
 - 生成单个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan`
 - 生成多个渠道包: `./gradlew clean assembleReleaseChannels -PchannelList=meituan,dianping`
-- 生成渠道包&写入额外信息:
+- 生成渠道包&写入额外信息:  
   `./gradlew clean assembleReleaseChannels -PchannelList=meituan -PextraInfo=buildtime:20161212,hash:xxxxxxx`
   注意: 这里的extraInfo以`key:value`形式提供，多个以`,`分隔。
 

--- a/app/config.json
+++ b/app/config.json
@@ -8,37 +8,61 @@
     "key2": "20161213",
     "key": "20161212"
   },
+
+  /*
+    strategy:
+     1. ifNone (默认适用此策略) : 仅当对应channel没有extraInfo时生效
+     2. always : 所有channel都生效，channel中extraInfo的key与defaultExtraInfo重复时，覆盖defaultExtraInfo中的内容。
+   */
+
+  //"defaultExtraInfoStrategy": "always",
+
   "channelInfoList": [
     {
-      "channel": "meituan", // 此channel将使用自己声明的extraInfo
-      /**
+      "channel": "meituan",
+      // 此channel将使用自己声明的extraInfo
+      /*
       此alias可以做到写入apk的channel是meituan，而打包时输出的文件名是美团
       注意：alias不声明时，walle配置apkFileNameFormat中channel就是channel，否则为alias
       */
-      "alias" : "美团",
+      "alias": "美团",
       "extraInfo": {
         "buildtime": "20161212",
         "hash": "123"
       }
     },
     {
-      "channel": "360cn", // 此channel将使用自己声明的extraInfo
+      "channel": "360cn",
+      // 此channel将使用自己声明的extraInfo
       "extraInfo": {
-        "key": "20161212"
+        "key": "20161213"
       }
     },
     {
+      "channel": "googleplay"
+      // 此channel将使用defaultExtraInfo
+    },
+    {
+      "channel": "xiaomi"
+      // 此channel将使用defaultExtraInfo
+    },
+    {
+      "channel": "meizu"
+      // 此channel将使用defaultExtraInfo
+    },
+    {
+      "channel": "wandoujia",
+      "excludeDefaultExtraInfo": true
+      //强制声明不使用defaultExtraInfo，默认false
+    },
+    {
       "channel": "myapp",
-      "extraInfo": {} //强制声明不使用defaultExtraInfo
-    },
-    {
-      "channel": "googleplay" // 此channel将使用defaultExtraInfo
-    },
-    {
-      "channel": "xiaomi" // 此channel将使用defaultExtraInfo
-    },
-    {
-      "channel": "meizu" // 此channel将使用defaultExtraInfo
+      "excludeDefaultExtraInfo": true,
+      //强制声明不使用defaultExtraInfo，默认false
+      "extraInfo": {
+        // 尽管exclude default，但也可以继续写入自己的。
+        "key": "20161212"
+      }
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=1.1.1
+VERSION_NAME=1.1.2
 GROUP=com.meituan.android.walle

--- a/plugin/src/main/groovy/com/meituan/android/walle/ChannelMaker.groovy
+++ b/plugin/src/main/groovy/com/meituan/android/walle/ChannelMaker.groovy
@@ -38,6 +38,9 @@ class ChannelMaker extends DefaultTask {
         group "Package"
     }
 
+    private static final String PROPERTY_CHANNEL_LIST = 'channelList'
+    private static final String PROPERTY_EXTRA_INFO = 'extraInfo'
+
     @TaskAction
     public void packaging() {
         Extension extension = Extension.getConfig(targetProject);
@@ -90,7 +93,31 @@ class ChannelMaker extends DefaultTask {
                     'flavorName' : variant.flavorName
             ]
 
-            if (extension.configFile instanceof File) {
+            if (targetProject.hasProperty(PROPERTY_CHANNEL_LIST)) {
+
+                def channelList = new ArrayList<String>()
+                def channelListProperty = targetProject.getProperties().get(PROPERTY_CHANNEL_LIST)
+                if (channelListProperty != null && channelListProperty.trim().length() > 0) {
+                    channelList.addAll(channelListProperty.split(",").collect { it.trim() })
+                }
+                def extraInfo = null;
+                def extraInfoString = targetProject.getProperties().get(PROPERTY_EXTRA_INFO)
+                if (extraInfoString != null && extraInfoString.trim().length() > 0) {
+                    def keyValues = extraInfoString.split(",").collect {
+                        it.trim()
+                    }
+                    extraInfo = keyValues.findAll {
+                        it.split(":").size() == 2
+                    }.collectEntries([:]) { keyValue ->
+                        def data = keyValue.split(":")
+                        [data[0], data[1]]
+                    }
+                }
+                channelList.each { channel ->
+                    generateChannelApk(apkFile, channelOutputFolder, nameVariantMap, channel, extraInfo, null)
+                }
+
+            } else if (extension.configFile instanceof File) {
                 if (!extension.configFile.exists()) {
                     project.logger.warn("config file does not exist")
                     return
@@ -99,9 +126,28 @@ class ChannelMaker extends DefaultTask {
                 def defaultExtraInfo = config.getDefaultExtraInfo()
                 config.getChannelInfoList().each { channelInfo ->
                     def extraInfo = channelInfo.extraInfo
-                    if (extraInfo == null) {
-                        extraInfo = defaultExtraInfo
+                    if (!channelInfo.excludeDefaultExtraInfo) {
+                        switch (config.defaultExtraInfoStrategy) {
+                            case WalleConfig.STRATEGY_IF_NONE:
+                                if (extraInfo == null) {
+                                    extraInfo = defaultExtraInfo
+                                }
+                                break;
+                            case WalleConfig.STRATEGY_ALWAYS:
+                                def temp = new HashMap<String, String>()
+                                if (defaultExtraInfo != null) {
+                                    temp.putAll(defaultExtraInfo)
+                                }
+                                if (extraInfo != null) {
+                                    temp.putAll(extraInfo)
+                                }
+                                extraInfo = temp
+                                break;
+                            default:
+                                break;
+                        }
                     }
+
                     generateChannelApk(apkFile, channelOutputFolder, nameVariantMap, channelInfo.channel, extraInfo, channelInfo.alias)
                 }
             } else if (extension.channelFile instanceof File) {
@@ -121,13 +167,13 @@ class ChannelMaker extends DefaultTask {
     static def getChannelListFromFile(File channelFile) {
         def channelList = []
         channelFile.eachLine { line ->
-                def lineTrim = line.trim()
-                if (lineTrim.length() != 0 && !lineTrim.startsWith("#")) {
-                    def channel = line.split("#").first().trim()
-                    if (channel.length() != 0)
-                        channelList.add(channel)
-                }
+            def lineTrim = line.trim()
+            if (lineTrim.length() != 0 && !lineTrim.startsWith("#")) {
+                def channel = line.split("#").first().trim()
+                if (channel.length() != 0)
+                    channelList.add(channel)
             }
+        }
         return channelList
     }
 

--- a/plugin/src/main/java/com/meituan/android/walle/WalleConfig.java
+++ b/plugin/src/main/java/com/meituan/android/walle/WalleConfig.java
@@ -5,14 +5,31 @@ import java.util.Map;
 
 public class WalleConfig {
 
+    /**
+     * strategy:
+     * 1. ifNone (默认适用此策略) : 仅当对应channel没有extraInfo时生效
+     * 2. always : 所有channel都生效，channel中extraInfo的key与defaultExtraInfo重复时，覆盖defaultExtraInfo中的内容。
+     */
+    public static final String STRATEGY_IF_NONE = "ifNone";
+    public static final String STRATEGY_ALWAYS = "always";
+    private String defaultExtraInfoStrategy = STRATEGY_IF_NONE;
+
+    public String getDefaultExtraInfoStrategy() {
+        return defaultExtraInfoStrategy;
+    }
+
+    public void setDefaultExtraInfoStrategy(String defaultExtraInfoStrategy) {
+        this.defaultExtraInfoStrategy = defaultExtraInfoStrategy;
+    }
+
     private Map<String, String> defaultExtraInfo;
 
     public List<ChannelInfo> getChannelInfoList() {
         return channelInfoList;
     }
 
-    public void setChannelInfoList(List<ChannelInfo> channelInfosList) {
-        this.channelInfoList = channelInfosList;
+    public void setChannelInfoList(List<ChannelInfo> channelInfoList) {
+        this.channelInfoList = channelInfoList;
     }
 
     private List<ChannelInfo> channelInfoList;
@@ -35,6 +52,15 @@ public class WalleConfig {
 
         public void setAlias(String alias) {
             this.alias = alias;
+        }
+
+        /**
+         * 强制声明不使用defaultExtraInfo参数
+         */
+        private boolean excludeDefaultExtraInfo = false;
+
+        public boolean isExcludeDefaultExtraInfo() {
+            return excludeDefaultExtraInfo;
         }
 
         private Map<String, String> extraInfo;

--- a/walle-cli/src/main/java/com/meituan/android/walle/WalleConfig.java
+++ b/walle-cli/src/main/java/com/meituan/android/walle/WalleConfig.java
@@ -5,14 +5,31 @@ import java.util.Map;
 
 public class WalleConfig {
 
+    /**
+     * strategy:
+     * 1. ifNone (默认适用此策略) : 仅当对应channel没有extraInfo时生效
+     * 2. always : 所有channel都生效，channel中extraInfo的key与defaultExtraInfo重复时，覆盖defaultExtraInfo中的内容。
+     */
+    public static final String STRATEGY_IF_NONE = "ifNone";
+    public static final String STRATEGY_ALWAYS = "always";
+    private String defaultExtraInfoStrategy = STRATEGY_IF_NONE;
+
+    public String getDefaultExtraInfoStrategy() {
+        return defaultExtraInfoStrategy;
+    }
+
+    public void setDefaultExtraInfoStrategy(final String defaultExtraInfoStrategy) {
+        this.defaultExtraInfoStrategy = defaultExtraInfoStrategy;
+    }
+
     private Map<String, String> defaultExtraInfo;
 
     public List<ChannelInfo> getChannelInfoList() {
         return channelInfoList;
     }
 
-    public void setChannelInfoList(final List<ChannelInfo> channelInfosList) {
-        this.channelInfoList = channelInfosList;
+    public void setChannelInfoList(final List<ChannelInfo> channelInfoList) {
+        this.channelInfoList = channelInfoList;
     }
 
     private List<ChannelInfo> channelInfoList;
@@ -37,6 +54,15 @@ public class WalleConfig {
             this.alias = alias;
         }
 
+        /**
+         * 强制声明不使用defaultExtraInfo参数
+         */
+        private boolean excludeDefaultExtraInfo = false;
+
+        public boolean isExcludeDefaultExtraInfo() {
+            return excludeDefaultExtraInfo;
+        }
+
         private Map<String, String> extraInfo;
 
         public String getChannel() {
@@ -56,3 +82,4 @@ public class WalleConfig {
         }
     }
 }
+

--- a/walle-cli/src/main/java/com/meituan/android/walle/WalleConfig.java
+++ b/walle-cli/src/main/java/com/meituan/android/walle/WalleConfig.java
@@ -57,7 +57,7 @@ public class WalleConfig {
         /**
          * 强制声明不使用defaultExtraInfo参数
          */
-        private boolean excludeDefaultExtraInfo = false;
+        private boolean excludeDefaultExtraInfo;
 
         public boolean isExcludeDefaultExtraInfo() {
             return excludeDefaultExtraInfo;

--- a/walle-cli/src/main/java/com/meituan/android/walle/commands/Batch2Command.java
+++ b/walle-cli/src/main/java/com/meituan/android/walle/commands/Batch2Command.java
@@ -55,7 +55,7 @@ public class Batch2Command implements IWalleCommand {
                                 }
                                 break;
                             case WalleConfig.STRATEGY_ALWAYS:
-                                Map<String, String> temp = new HashMap<>();
+                                final Map<String, String> temp = new HashMap<>();
                                 if (defaultExtraInfo != null) {
                                     temp.putAll(defaultExtraInfo);
                                 }

--- a/walle-cli/src/main/java/com/meituan/android/walle/commands/Batch2Command.java
+++ b/walle-cli/src/main/java/com/meituan/android/walle/commands/Batch2Command.java
@@ -14,6 +14,7 @@ import org.apache.commons.io.FilenameUtils;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,8 +47,26 @@ public class Batch2Command implements IWalleCommand {
                 final List<WalleConfig.ChannelInfo> channelInfoList = config.getChannelInfoList();
                 for (WalleConfig.ChannelInfo channelInfo : channelInfoList) {
                     Map<String, String> extraInfo = channelInfo.getExtraInfo();
-                    if (extraInfo == null) {
-                        extraInfo = defaultExtraInfo;
+                    if (!channelInfo.isExcludeDefaultExtraInfo()) {
+                        switch (config.getDefaultExtraInfoStrategy()) {
+                            case WalleConfig.STRATEGY_IF_NONE:
+                                if (extraInfo == null) {
+                                    extraInfo = defaultExtraInfo;
+                                }
+                                break;
+                            case WalleConfig.STRATEGY_ALWAYS:
+                                Map<String, String> temp = new HashMap<>();
+                                if (defaultExtraInfo != null) {
+                                    temp.putAll(defaultExtraInfo);
+                                }
+                                if (extraInfo != null) {
+                                    temp.putAll(extraInfo);
+                                }
+                                extraInfo = temp;
+                                break;
+                            default:
+                                break;
+                        }
                     }
                     generateChannelApk(inputFile, outputDir, channelInfo.getChannel(), channelInfo.getAlias(), extraInfo);
                 }


### PR DESCRIPTION
1. 恢复-P参数能力，方便用户临时生成渠道包。
2. config.json新增defaultExtraInfoStrategy，用于标识当前defaultExtraInfo如何生效
    strategy:
      1. ifNone (默认适用此策略) : 仅当对应channel没有extraInfo时生效
      2. always : 所有channel都生效，channel中extraInfo的key与defaultExtraInfo重复时，覆盖defaultExtraInfo中的内容。
3. config.json新增"excludeDefaultExtraInfo": true，强制声明不使用defaultExtraInfo，默认false