### PR TITLE
低内存操作 & Payload api加强（提供string操作）

### DIFF
--- a/payload_reader/src/main/java/com/meituan/android/walle/ChannelReader.java
+++ b/payload_reader/src/main/java/com/meituan/android/walle/ChannelReader.java
@@ -4,7 +4,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -65,15 +64,6 @@ public final class ChannelReader {
      * @return null if not found
      */
     public static String getRaw(final File apkFile) {
-        final byte[] bytes = PayloadReader.get(apkFile, ApkUtil.APK_CHANNEL_BLOCK_ID);
-        if (bytes == null) {
-            return null;
-        }
-        try {
-            return new String(bytes, ApkUtil.DEFAULT_CHARSET);
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-        }
-        return null;
+        return  PayloadReader.getString(apkFile, ApkUtil.APK_CHANNEL_BLOCK_ID);
     }
 }

--- a/payload_reader/src/main/java/com/meituan/android/walle/PayloadReader.java
+++ b/payload_reader/src/main/java/com/meituan/android/walle/PayloadReader.java
@@ -3,6 +3,7 @@ package com.meituan.android.walle;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
@@ -11,6 +12,25 @@ import java.util.Map;
 public final class PayloadReader {
     private PayloadReader() {
         super();
+    }
+
+    /**
+     * get string (UTF-8) by id
+     *
+     * @param apkFile apk file
+     * @return null if not found
+     */
+    public static String getString(final File apkFile, final int id) {
+        final byte[] bytes = PayloadReader.get(apkFile, id);
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            return new String(bytes, ApkUtil.DEFAULT_CHARSET);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     /**

--- a/payload_writer/src/main/java/com/meituan/android/walle/ChannelWriter.java
+++ b/payload_writer/src/main/java/com/meituan/android/walle/ChannelWriter.java
@@ -29,7 +29,7 @@ public final class ChannelWriter {
      *
      * @param apkFile apk file
      * @param channel channel
-     * @param lowMemory if need low memory operation
+     * @param lowMemory if need low memory operation, maybe a little slower
      * @throws IOException
      * @throws SignatureNotFoundException
      */
@@ -54,7 +54,7 @@ public final class ChannelWriter {
      * @param apkFile   apk file
      * @param channel   channel （nullable)
      * @param extraInfo extra info (don't use {@link ChannelReader#CHANNEL_KEY PayloadReader.CHANNEL_KEY} as your key)
-     * @param lowMemory if need low memory operation
+     * @param lowMemory if need low memory operation, maybe a little slower
      * @throws IOException
      * @throws SignatureNotFoundException
      */
@@ -88,12 +88,12 @@ public final class ChannelWriter {
         putRaw(apkFile, string, false);
     }
     /**
-     * write custom content with channel fixed id, low memory operation <br/>
+     * write custom content with channel fixed id<br/>
      * NOTE: {@link ChannelReader#get(File)}  and {@link ChannelReader#getMap(File)}  may be affected
      *
      * @param apkFile apk file
      * @param string  custom content
-     * @param lowMemory if need low memory operation
+     * @param lowMemory if need low memory operation, maybe a little slower
      * @throws IOException
      * @throws SignatureNotFoundException
      */
@@ -114,7 +114,7 @@ public final class ChannelWriter {
      * remove channel id content
      *
      * @param apkFile apk file
-     * @param lowMemory if need low memory operation
+     * @param lowMemory if need low memory operation, maybe a little slower
      * @throws IOException
      * @throws SignatureNotFoundException
      */

--- a/payload_writer/src/main/java/com/meituan/android/walle/ChannelWriter.java
+++ b/payload_writer/src/main/java/com/meituan/android/walle/ChannelWriter.java
@@ -4,11 +4,8 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 
 public final class ChannelWriter {
@@ -25,9 +22,20 @@ public final class ChannelWriter {
      * @throws SignatureNotFoundException
      */
     public static void put(final File apkFile, final String channel) throws IOException, SignatureNotFoundException {
-        put(apkFile, channel, null);
+        put(apkFile, channel, false);
     }
-
+    /**
+     * write channel with channel fixed id
+     *
+     * @param apkFile apk file
+     * @param channel channel
+     * @param lowMemory if need low memory operation
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void put(final File apkFile, final String channel, final boolean lowMemory) throws IOException, SignatureNotFoundException {
+        put(apkFile, channel, null, lowMemory);
+    }
     /**
      * write channel & extra info with channel fixed id
      *
@@ -38,6 +46,19 @@ public final class ChannelWriter {
      * @throws SignatureNotFoundException
      */
     public static void put(final File apkFile, final String channel, final Map<String, String> extraInfo) throws IOException, SignatureNotFoundException {
+        put(apkFile, channel, extraInfo, false);
+    }
+    /**
+     * write channel & extra info with channel fixed id
+     *
+     * @param apkFile   apk file
+     * @param channel   channel （nullable)
+     * @param extraInfo extra info (don't use {@link ChannelReader#CHANNEL_KEY PayloadReader.CHANNEL_KEY} as your key)
+     * @param lowMemory if need low memory operation
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void put(final File apkFile, final String channel, final Map<String, String> extraInfo, final boolean lowMemory) throws IOException, SignatureNotFoundException {
         final Map<String, String> newData = new HashMap<String, String>();
         final Map<String, String> existsData = ChannelReader.getMap(apkFile);
         if (existsData != null) {
@@ -52,9 +73,8 @@ public final class ChannelWriter {
             newData.put(ChannelReader.CHANNEL_KEY, channel);
         }
         final JSONObject jsonObject = new JSONObject(newData);
-        putRaw(apkFile, jsonObject.toString());
+        putRaw(apkFile, jsonObject.toString(), lowMemory);
     }
-
     /**
      * write custom content with channel fixed id <br/>
      * NOTE: {@link ChannelReader#get(File)}  and {@link ChannelReader#getMap(File)}  may be affected
@@ -65,14 +85,21 @@ public final class ChannelWriter {
      * @throws SignatureNotFoundException
      */
     public static void putRaw(final File apkFile, final String string) throws IOException, SignatureNotFoundException {
-        final byte[] bytes = string.getBytes(ApkUtil.DEFAULT_CHARSET);
-        final ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
-        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-        byteBuffer.put(bytes, 0, bytes.length);
-        byteBuffer.flip();
-        PayloadWriter.put(apkFile, ApkUtil.APK_CHANNEL_BLOCK_ID, byteBuffer);
+        putRaw(apkFile, string, false);
     }
-
+    /**
+     * write custom content with channel fixed id, low memory operation <br/>
+     * NOTE: {@link ChannelReader#get(File)}  and {@link ChannelReader#getMap(File)}  may be affected
+     *
+     * @param apkFile apk file
+     * @param string  custom content
+     * @param lowMemory if need low memory operation
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void putRaw(final File apkFile, final String string, final boolean lowMemory) throws IOException, SignatureNotFoundException {
+        PayloadWriter.put(apkFile, ApkUtil.APK_CHANNEL_BLOCK_ID, string, lowMemory);
+    }
     /**
      * remove channel id content
      *
@@ -81,20 +108,17 @@ public final class ChannelWriter {
      * @throws SignatureNotFoundException
      */
     public static void remove(final File apkFile) throws IOException, SignatureNotFoundException {
-        PayloadWriter.handleApkSigningBlock(apkFile, new PayloadWriter.ApkSigningBlockHandler() {
-            @Override
-            public ApkSigningBlock handle(final Map<Integer, ByteBuffer> originIdValues) {
-                final ApkSigningBlock apkSigningBlock = new ApkSigningBlock();
-                final Set<Map.Entry<Integer, ByteBuffer>> entrySet = originIdValues.entrySet();
-                for (Map.Entry<Integer, ByteBuffer> entry : entrySet) {
-                    if (entry.getKey() != ApkUtil.APK_CHANNEL_BLOCK_ID) {
-                        final ApkSigningPayload payload = new ApkSigningPayload(entry.getKey(), entry.getValue());
-                        apkSigningBlock.addPayload(payload);
-                    }
-                }
-                return apkSigningBlock;
-            }
-        });
+        remove(apkFile, false);
     }
-
+    /**
+     * remove channel id content
+     *
+     * @param apkFile apk file
+     * @param lowMemory if need low memory operation
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void remove(final File apkFile, final boolean lowMemory) throws IOException, SignatureNotFoundException {
+        PayloadWriter.remove(apkFile, ApkUtil.APK_CHANNEL_BLOCK_ID, lowMemory);
+    }
 }

--- a/payload_writer/src/main/java/com/meituan/android/walle/PayloadWriter.java
+++ b/payload_writer/src/main/java/com/meituan/android/walle/PayloadWriter.java
@@ -20,7 +20,7 @@ public final class PayloadWriter {
     }
 
     /**
-     * put (id, String) into apk, update if id exists,  not low memory operation
+     * put (id, String) into apk, update if id exists
      * @param apkFile apk file
      * @param id id
      * @param string string content
@@ -35,7 +35,7 @@ public final class PayloadWriter {
      * @param apkFile apk file
      * @param id id
      * @param string string
-     * @param lowMemory if need low memory operation
+     * @param lowMemory if need low memory operation, maybe a little slower
      * @throws IOException
      * @throws SignatureNotFoundException
      */
@@ -48,7 +48,7 @@ public final class PayloadWriter {
         put(apkFile, id, byteBuffer, lowMemory);
     }
     /**
-     * put (id, buffer) into apk, update if id exists , not low memory operation
+     * put (id, buffer) into apk, update if id exists
      *
      * @param apkFile apk file
      * @param id      id
@@ -65,7 +65,7 @@ public final class PayloadWriter {
      * @param apkFile apk file
      * @param id id
      * @param buffer buffer
-     * @param lowMemory if need low memory operation
+     * @param lowMemory if need low memory operation, maybe a little slower
      * @throws IOException
      * @throws SignatureNotFoundException
      */
@@ -75,7 +75,7 @@ public final class PayloadWriter {
         putAll(apkFile, idValues, lowMemory);
     }
     /**
-     * put new idValues into apk, update if id exists, not low memory operation
+     * put new idValues into apk, update if id exists
      *
      * @param apkFile  apk file
      * @param idValues id value. NOTE: use unknown IDs. DO NOT use ID that have already been used.  See <a href='https://source.android.com/security/apksigning/v2.html'>APK Signature Scheme v2</a>
@@ -90,7 +90,7 @@ public final class PayloadWriter {
      *
      * @param apkFile  apk file
      * @param idValues id value. NOTE: use unknown IDs. DO NOT use ID that have already been used.  See <a href='https://source.android.com/security/apksigning/v2.html'>APK Signature Scheme v2</a>
-     * @param lowMemory if need low memory operation
+     * @param lowMemory if need low memory operation, maybe a little slower
      * @throws IOException
      * @throws SignatureNotFoundException
      */
@@ -127,7 +127,7 @@ public final class PayloadWriter {
      *
      * @param apkFile apk file
      * @param id id
-     * @param lowMemory  if need low memory operation
+     * @param lowMemory  if need low memory operation, maybe a little slower
      * @throws IOException
      * @throws SignatureNotFoundException
      */
@@ -190,7 +190,7 @@ public final class PayloadWriter {
                     FileOutputStream outStream = null;
                     try {
                         outStream = new FileOutputStream(tempCentralBytesFile);
-                        byte[] buffer = new byte[1024];
+                        final byte[] buffer = new byte[1024];
 
                         int len;
                         while ((len = fIn.read(buffer)) > 0){
@@ -215,7 +215,7 @@ public final class PayloadWriter {
                     FileInputStream inputStream = null;
                     try {
                         inputStream = new FileInputStream(tempCentralBytesFile);
-                        byte[] buffer = new byte[1024];
+                        final byte[] buffer = new byte[1024];
 
                         int len;
                         while ((len = inputStream.read(buffer)) > 0){

--- a/payload_writer/src/main/java/com/meituan/android/walle/PayloadWriter.java
+++ b/payload_writer/src/main/java/com/meituan/android/walle/PayloadWriter.java
@@ -1,6 +1,8 @@
 package com.meituan.android.walle;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
@@ -9,6 +11,7 @@ import java.nio.channels.FileChannel;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 
 public final class PayloadWriter {
@@ -17,7 +20,35 @@ public final class PayloadWriter {
     }
 
     /**
-     * put (id, buffer) into apk, update if id exists
+     * put (id, String) into apk, update if id exists,  not low memory operation
+     * @param apkFile apk file
+     * @param id id
+     * @param string string content
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void put(final File apkFile, final int id, final String string) throws IOException, SignatureNotFoundException {
+        put(apkFile, id, string, false);
+    }
+    /**
+     * put (id, String) into apk, update if id exists
+     * @param apkFile apk file
+     * @param id id
+     * @param string string
+     * @param lowMemory if need low memory operation
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void put(final File apkFile, final int id, final String string, final boolean lowMemory) throws IOException, SignatureNotFoundException {
+        final byte[] bytes = string.getBytes(ApkUtil.DEFAULT_CHARSET);
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(bytes.length);
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        byteBuffer.put(bytes, 0, bytes.length);
+        byteBuffer.flip();
+        put(apkFile, id, byteBuffer, lowMemory);
+    }
+    /**
+     * put (id, buffer) into apk, update if id exists , not low memory operation
      *
      * @param apkFile apk file
      * @param id      id
@@ -26,13 +57,25 @@ public final class PayloadWriter {
      * @throws SignatureNotFoundException
      */
     public static void put(final File apkFile, final int id, final ByteBuffer buffer) throws IOException, SignatureNotFoundException {
-        final Map<Integer, ByteBuffer> idValues = new HashMap<Integer, ByteBuffer>();
-        idValues.put(id, buffer);
-        putAll(apkFile, idValues);
+        put(apkFile, id, buffer, false);
     }
 
     /**
-     * put new idValues into apk, update if id exists
+     * put (id, buffer) into apk, update if id exists
+     * @param apkFile apk file
+     * @param id id
+     * @param buffer buffer
+     * @param lowMemory if need low memory operation
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void put(final File apkFile, final int id, final ByteBuffer buffer, final boolean lowMemory) throws IOException, SignatureNotFoundException {
+        final Map<Integer, ByteBuffer> idValues = new HashMap<Integer, ByteBuffer>();
+        idValues.put(id, buffer);
+        putAll(apkFile, idValues, lowMemory);
+    }
+    /**
+     * put new idValues into apk, update if id exists, not low memory operation
      *
      * @param apkFile  apk file
      * @param idValues id value. NOTE: use unknown IDs. DO NOT use ID that have already been used.  See <a href='https://source.android.com/security/apksigning/v2.html'>APK Signature Scheme v2</a>
@@ -40,6 +83,18 @@ public final class PayloadWriter {
      * @throws SignatureNotFoundException
      */
     public static void putAll(final File apkFile, final Map<Integer, ByteBuffer> idValues) throws IOException, SignatureNotFoundException {
+        putAll(apkFile, idValues, false);
+    }
+    /**
+     * put new idValues into apk, update if id exists
+     *
+     * @param apkFile  apk file
+     * @param idValues id value. NOTE: use unknown IDs. DO NOT use ID that have already been used.  See <a href='https://source.android.com/security/apksigning/v2.html'>APK Signature Scheme v2</a>
+     * @param lowMemory if need low memory operation
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void putAll(final File apkFile, final Map<Integer, ByteBuffer> idValues, final boolean lowMemory) throws IOException, SignatureNotFoundException {
         handleApkSigningBlock(apkFile, new ApkSigningBlockHandler() {
             @Override
             public ApkSigningBlock handle(final Map<Integer, ByteBuffer> originIdValues) {
@@ -54,14 +109,50 @@ public final class PayloadWriter {
                 }
                 return apkSigningBlock;
             }
-        });
+        }, lowMemory);
+    }
+    /**
+     * remove content by id
+     *
+     * @param apkFile apk file
+     * @param id id
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void remove(final File apkFile, final int id) throws IOException, SignatureNotFoundException {
+        remove(apkFile, id, false);
+    }
+    /**
+     * remove content by id
+     *
+     * @param apkFile apk file
+     * @param id id
+     * @param lowMemory  if need low memory operation
+     * @throws IOException
+     * @throws SignatureNotFoundException
+     */
+    public static void remove(final File apkFile, final int id, final boolean lowMemory) throws IOException, SignatureNotFoundException {
+        PayloadWriter.handleApkSigningBlock(apkFile, new PayloadWriter.ApkSigningBlockHandler() {
+            @Override
+            public ApkSigningBlock handle(final Map<Integer, ByteBuffer> originIdValues) {
+                final ApkSigningBlock apkSigningBlock = new ApkSigningBlock();
+                final Set<Map.Entry<Integer, ByteBuffer>> entrySet = originIdValues.entrySet();
+                for (Map.Entry<Integer, ByteBuffer> entry : entrySet) {
+                    if (entry.getKey() != id) {
+                        final ApkSigningPayload payload = new ApkSigningPayload(entry.getKey(), entry.getValue());
+                        apkSigningBlock.addPayload(payload);
+                    }
+                }
+                return apkSigningBlock;
+            }
+        }, lowMemory);
     }
 
     interface ApkSigningBlockHandler {
         ApkSigningBlock handle(Map<Integer, ByteBuffer> originIdValues);
     }
 
-    static void handleApkSigningBlock(final File apkFile, final ApkSigningBlockHandler handler) throws IOException, SignatureNotFoundException {
+    static void handleApkSigningBlock(final File apkFile, final ApkSigningBlockHandler handler, final boolean lowMemory) throws IOException, SignatureNotFoundException {
         RandomAccessFile fIn = null;
         FileChannel fileChannel = null;
         try {
@@ -90,15 +181,56 @@ public final class PayloadWriter {
 
                 // read CentralDir
                 fIn.seek(centralDirStartOffset);
-                final byte[] centralDirBytes = new byte[(int) (fileChannel.size() - centralDirStartOffset)];
-                fIn.read(centralDirBytes);
 
+                byte[] centralDirBytes = null;
+                File tempCentralBytesFile = null;
+                // read CentralDir
+                if (lowMemory) {
+                    tempCentralBytesFile = new File(apkFile.getParent(), UUID.randomUUID().toString());
+                    FileOutputStream outStream = null;
+                    try {
+                        outStream = new FileOutputStream(tempCentralBytesFile);
+                        byte[] buffer = new byte[1024];
+
+                        int len;
+                        while ((len = fIn.read(buffer)) > 0){
+                            outStream.write(buffer, 0, len);
+                        }
+                    } finally {
+                        if (outStream != null) {
+                            outStream.close();
+                        }
+                    }
+                } else {
+                    centralDirBytes = new byte[(int) (fileChannel.size() - centralDirStartOffset)];
+                    fIn.read(centralDirBytes);
+                }
+
+                //update apk sign
                 fileChannel.position(apkSigningBlockOffset);
-
                 final long length = apkSigningBlock.writeApkSigningBlock(fIn);
 
-                // store CentralDir
-                fIn.write(centralDirBytes);
+                // update CentralDir
+                if (lowMemory) {
+                    FileInputStream inputStream = null;
+                    try {
+                        inputStream = new FileInputStream(tempCentralBytesFile);
+                        byte[] buffer = new byte[1024];
+
+                        int len;
+                        while ((len = inputStream.read(buffer)) > 0){
+                            fIn.write(buffer, 0, len);
+                        }
+                    } finally {
+                        if (inputStream != null) {
+                            inputStream.close();
+                        }
+                        tempCentralBytesFile.delete();
+                    }
+                } else {
+                    // store CentralDir
+                    fIn.write(centralDirBytes);
+                }
                 // update length
                 fIn.setLength(fIn.getFilePointer());
 
@@ -127,14 +259,11 @@ public final class PayloadWriter {
 
             }
         } finally {
-            try {
-                if (fileChannel != null) {
-                    fileChannel.close();
-                }
-                if (fIn != null) {
-                    fIn.close();
-                }
-            } catch (IOException e) {
+            if (fileChannel != null) {
+                fileChannel.close();
+            }
+            if (fIn != null) {
+                fIn.close();
             }
         }
     }


### PR DESCRIPTION
1. 提供低内存操作，便于Android设备使用写入
原centralDirBytes一次性读取到内存（1.3M左右），有可能触发OOM异常。
开发者选择低内存操作时先读取到文件，写完apk sign后再读取写回来
2. Channel中一些操作下沉到PayLoad，便于直接使用Payload