### PR TITLE
放弃latest.integration 使用 & 减少copy

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -2,6 +2,12 @@ apply plugin: 'groovy'
 apply from: rootProject.file("mt_maven.gradle")
 //apply from: rootProject.file('quality.gradle')
 
+jar {
+    manifest {
+        attributes 'Walle-Version': VERSION_NAME
+    }
+}
+
 dependencies {
     compile gradleApi()
     compile localGroovy()

--- a/plugin/src/main/groovy/com/meituan/android/walle/ChannelMaker.groovy
+++ b/plugin/src/main/groovy/com/meituan/android/walle/ChannelMaker.groovy
@@ -235,8 +235,7 @@ class ChannelMaker extends DefaultTask {
         if (extension.apkFileNameFormat != null && extension.apkFileNameFormat.length() > 0) {
             def newApkFileName = new SimpleTemplateEngine().createTemplate(extension.apkFileNameFormat).make(nameVariantMap).toString()
             if (!newApkFileName.contentEquals(apkFileName)) {
-                FileUtils.copyFile(channelApkFile, new File(newApkFileName, channelOutputFolder));
-                channelApkFile.delete();
+                channelApkFile.renameTo(new File(newApkFileName, channelOutputFolder))
             }
         }
     }

--- a/plugin/src/main/groovy/com/meituan/android/walle/GradlePlugin.groovy
+++ b/plugin/src/main/groovy/com/meituan/android/walle/GradlePlugin.groovy
@@ -7,6 +7,10 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 
+import java.util.jar.Attributes
+import java.util.jar.JarFile
+import java.util.jar.Manifest
+
 class GradlePlugin implements org.gradle.api.Plugin<Project> {
 
     public static final String sPluginExtensionName = "walle";
@@ -22,7 +26,7 @@ class GradlePlugin implements org.gradle.api.Plugin<Project> {
         }
 
         project.dependencies {
-            compile 'com.meituan.android.walle:library:latest.integration'
+            compile 'com.meituan.android.walle:library:' + getVersion()
         }
 
         applyExtension(project);
@@ -107,5 +111,29 @@ class GradlePlugin implements org.gradle.api.Plugin<Project> {
         else {
             return Integer.signum(vals1.length - vals2.length);
         }
+    }
+    private static String getVersion() {
+        try {
+            final Enumeration resEnum = Thread.currentThread().getContextClassLoader().getResources(JarFile.MANIFEST_NAME);
+            while (resEnum.hasMoreElements()) {
+                try {
+                    final URL url = (URL) resEnum.nextElement();
+                    final InputStream is = url.openStream();
+                    if (is != null) {
+                        final Manifest manifest = new Manifest(is);
+                        final Attributes mainAttribs = manifest.getMainAttributes();
+                        final String version = mainAttribs.getValue("Walle-Version");
+                        if (version != null) {
+                            return version;
+                        }
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        } catch (IOException e1) {
+            e1.printStackTrace();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
1. 放弃latest.integration 使用，避免目前gfw或者未来版本不适配引起问题，改为plugin插件版本引用对应版本aar形式
fix https://github.com/Meituan-Dianping/walle/issues/141
fix https://github.com/Meituan-Dianping/walle/issues/133
2. 减少不必要copy，改为renameTo