### PR TITLE
解决与最新apksigner（build-tools 28.0.x) 的兼容性问题

### DIFF
--- a/payload_reader/src/main/java/com/meituan/android/walle/ApkUtil.java
+++ b/payload_reader/src/main/java/com/meituan/android/walle/ApkUtil.java
@@ -27,6 +27,15 @@ final class ApkUtil {
       */
     public static final int APK_SIGNATURE_SCHEME_V2_BLOCK_ID = 0x7109871a;
 
+    /**
+     * The padding in APK SIG BLOCK (V3 scheme introduced)
+     * See https://android.googlesource.com/platform/tools/apksig/+/master/src/main/java/com/android/apksig/internal/apk/ApkSigningBlockUtils.java
+     */
+    public static final int VERITY_PADDING_BLOCK_ID = 0x42726577;
+
+    public static final int ANDROID_COMMON_PAGE_ALIGNMENT_BYTES = 4096;
+
+
     // Our Channel Block ID
     public static final int APK_CHANNEL_BLOCK_ID = 0x71777777;
 

--- a/payload_writer/src/main/java/com/meituan/android/walle/ApkSigningPayload.java
+++ b/payload_writer/src/main/java/com/meituan/android/walle/ApkSigningPayload.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 class ApkSigningPayload {
     private final int id;
     private final ByteBuffer buffer;
+    private final int totalSize;
 
     ApkSigningPayload(final int id, final ByteBuffer buffer) {
         super();
@@ -15,6 +16,8 @@ class ApkSigningPayload {
             throw new IllegalArgumentException("ByteBuffer byte order must be little endian");
         }
         this.buffer = buffer;
+        // assume buffer is not consumed
+        this.totalSize = 8 + 4 + buffer.remaining(); // size + id + value
     }
 
     public int getId() {
@@ -26,5 +29,12 @@ class ApkSigningPayload {
         final int arrayOffset = buffer.arrayOffset();
         return Arrays.copyOfRange(array, arrayOffset + buffer.position(),
                 arrayOffset + buffer.limit());
+    }
+
+    /**
+     * Total bytes of this block
+     */
+    public int getTotalSize() {
+        return totalSize;
     }
 }


### PR DESCRIPTION
问题：输出的渠道包无法在android p 上安装，如果原始包是用的最新版 apksigner（build-tools 28.0.x) 签名

原因：android p 需要 apksigningblock 的长度确保为 4096 的倍数
https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/util/apk/ApkVerityBuilder.java#445

Fixed Meituan-Dianping/walle#256 Meituan-Dianping/walle#255