### PR TITLE
fix #374 read centralDirStartOffset fail when the apk filesize > 2g

### DIFF
--- a/payload_reader/src/main/java/com/meituan/android/walle/ApkUtil.java
+++ b/payload_reader/src/main/java/com/meituan/android/walle/ApkUtil.java
@@ -126,7 +126,7 @@ final class ApkUtil {
         zipCentralDirectoryStart.order(ByteOrder.LITTLE_ENDIAN);
         fileChannel.position(fileChannel.size() - commentLength - 6); // 6 = 2 (Comment length) + 4 (Offset of start of central directory, relative to start of archive)
         fileChannel.read(zipCentralDirectoryStart);
-        final long centralDirStartOffset = zipCentralDirectoryStart.getInt(0);
+        final long centralDirStartOffset = zipCentralDirectoryStart.getInt(0) & 0xFFFFFFFFL;
         return centralDirStartOffset;
     }
 


### PR DESCRIPTION
when the file length > 2G 
`Offset of start of central directory, relative to start of archive` > `signed int` 
the return value of `zipCentralDirectoryStart.getInt(0)` will overflow  

cast return value to long can fix the issue